### PR TITLE
first and last vessel transmission date mock

### DIFF
--- a/src/service/vessel.service.js
+++ b/src/service/vessel.service.js
@@ -11,6 +11,8 @@ const transformSearchResult = source => entry => {
     id: entry._id,
     ...entry._source,
     ...baseFields,
+    firstTransmissionDate: '2019-01-01T00:00:00.000Z',
+    lastTransmissionDate: '2020-01-01T00:00:00.000Z',
   };
 };
 
@@ -19,14 +21,16 @@ const calculateNextOffset = (query, results) =>
     ? query.offset + query.limit
     : null;
 
-const transformSearchResults = ({ query, source }) => results => ({
-  query: query.query,
-  total: results.hits.total,
-  limit: query.limit,
-  offset: query.offset,
-  nextOffset: calculateNextOffset(query, results),
-  entries: results.hits.hits.map(transformSearchResult(source)),
-});
+const transformSearchResults = ({ query, source }) => results => {
+  return {
+    query: query.query,
+    total: results.hits.total,
+    limit: query.limit,
+    offset: query.offset,
+    nextOffset: calculateNextOffset(query, results),
+    entries: results.hits.hits.map(transformSearchResult(source)),
+  };
+};
 
 const transformSuggestionsResults = ({
   results,

--- a/src/service/vessel.service.js
+++ b/src/service/vessel.service.js
@@ -7,12 +7,14 @@ const transformSearchResult = source => entry => {
     ? { tilesetId: source.tileset }
     : { dataset: source.dataset.name };
 
+  const { firstTimestamp: firstTransmissionDate, lastTimestamp: lastTransmissionDate, ...entrySource } = entry._source;
+
   return {
     id: entry._id,
-    ...entry._source,
+    ...entrySource,
     ...baseFields,
-    firstTransmissionDate: '2019-01-01T00:00:00.000Z',
-    lastTransmissionDate: '2020-01-01T00:00:00.000Z',
+    firstTransmissionDate,
+    lastTransmissionDate,
   };
 };
 


### PR DESCRIPTION
Using this as a mock for this https://trello.com/c/STi4kYi0/68-add-first-and-last-message-in-search-results to be implemented on the frontend.

It uses `firstTransmissionDate` and `lastTransmissionDate` as suggestions to the field names but just update it as needed to match the database fields.