### PR TITLE
Feature/refactor vessels endpoints

### DIFF
--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -466,11 +466,9 @@ paths:
   '/v1/vessels':
     get:
       summary: |
-        Searches for vessels
+        List vessels
       description: |
-        Searches for a vessel given a free form query. The query will be matched against any identifiers for the vessel,
-        and a paginated, ranked results list will be returned. Query and Ids are required depends on the case.
-        If you use query as parameter then you must not use ids and vice-versa.
+        Lists vessels given a list of vessels id.
       tags:
         - VesselsAPI
       parameters:
@@ -485,14 +483,60 @@ paths:
           in: query
           description: |
             List of vessel id to get these vessels. The ids must be separated by comma.
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: |
+            Amount of search results to return. Maximum 25.
           required: false
-            schema:
-              type: string
+          schema:
+            type: integer
+            maximum: 25
+            default: 10
+        - name: offset
+          in: query
+          description: |
+            Offset into the search results, used for pagination.
+          required: false
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: |
+            Expected response to a successful request.
+        '401':
+          description: Unauthorized, either the api key is invalid or expired.
+        '400':
+          description: Bad request. Invalid or wrong parameters were provided.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+
+  '/v1/vessels/search':
+    get:
+      summary: |
+        Search vessels
+      description: |
+        Searches for a vessel given a free form query. The query will be matched against any identifiers for the vessel, and a paginated, ranked results list will be returned.
+      tags:
+        - VesselsAPI
+      parameters:
+        - name: datasets
+          in: query
+          description: |
+            Dataset to query vessels from
+          required: true
+          schema:
+            type: string
         - name: query
           in: query
           description: |
             Search query.
-          required: false
+          required: true
           schema:
             type: string
         - name: queryFields
@@ -511,6 +555,60 @@ paths:
             type: string
             enum: [ shipname, imo, mmsi, flag ]
             default: shipname
+        - name: limit
+          in: query
+          description: |
+            Amount of search results to return. Maximum 25.
+          required: false
+          schema:
+            type: integer
+            maximum: 25
+            default: 10
+        - name: offset
+          in: query
+          description: |
+            Offset into the search results, used for pagination.
+          required: false
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: |
+            Expected response to a successful request.
+        '401':
+          description: Unauthorized, either the api key is invalid or expired.
+        '400':
+          description: Bad request. Invalid or wrong parameters were provided.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+
+  '/v1/vessels/advanced-search':
+    get:
+      summary: |
+        Search vessels
+      description: |
+        Searches for a vessel given a query (SQL syntax).
+      tags:
+        - VesselsAPI
+      parameters:
+        - name: datasets
+          in: query
+          description: |
+            Dataset to query vessels from
+          required: true
+          schema:
+            type: string
+        - name: query
+          in: query
+          description: |
+            Search query.
+          required: false
+          schema:
+            type: string
+          example: shipname LIKE 'GUAP%' and mmsi = '265555280'
         - name: limit
           in: query
           description: |

--- a/src/utils/remove-whitespace.js
+++ b/src/utils/remove-whitespace.js
@@ -1,0 +1,8 @@
+const removeWhitespace = str => {
+  return str
+    .replace(/%27/g, '\'')
+}
+
+module.exports = {
+  removeWhitespace
+}

--- a/src/utils/sanitize-sql.js
+++ b/src/utils/sanitize-sql.js
@@ -1,8 +1,15 @@
-function sanitizeSQL(sql) {
-  return sql
-    .replace(/%27/g, '\'')
-}
+const sanitizeSqlQuery = query => {
+  /*eslint-disable */
+  return query
+    .replace(/[*\+\-=~><\"\?^\${}\(\)\:\!\/[\]\\\s]/g, '\\$&')
+    .replace(/\|\|/g, '\\||') // replace ||
+    .replace(/\&\&/g, '\\&&')
+    .replace(/AND/g, '\\A\\N\\D')
+    .replace(/OR/g, '\\O\\R')
+    .replace(/NOT/g, '\\N\\O\\T');
+  /* eslint-enable */
+};
 
 module.exports = {
-  sanitizeSQL
+  sanitizeSqlQuery
 }

--- a/src/utils/split-datasets.js
+++ b/src/utils/split-datasets.js
@@ -1,0 +1,9 @@
+function splitDatasets(datasetsFromQuery) {
+  return datasetsFromQuery
+    .split(',')
+    .map(d => (d.indexOf(':') === -1 ? `${d}:latest` : d));
+}
+
+module.exports = {
+  splitDatasets
+}

--- a/src/validation/schemas/vessel.schemas.js
+++ b/src/validation/schemas/vessel.schemas.js
@@ -1,0 +1,55 @@
+const Joi = require('@hapi/joi');
+const { VESSELS_CONSTANTS: { DEFAULT_PROPERTY_SUGGEST } } = require('../constant');
+
+const vesselDefault = {
+  offset: 0,
+  queryFields: [],
+  suggestField: DEFAULT_PROPERTY_SUGGEST,
+  querySuggestions: false,
+  limit: 10,
+  binary: false,
+};
+
+const schemaGetAllVesselsV1 = Joi.object({
+  limit: Joi.number()
+    .integer()
+    .min(1)
+    .max(25)
+    .default(vesselDefault.limit),
+  binary: Joi.boolean().default(vesselDefault.binary),
+  ids: Joi.string().required(),
+  offset: Joi.number()
+    .integer()
+    .min(0)
+    .default(vesselDefault.offset),
+  datasets: Joi.string().required(),
+});
+
+const schemaGetVesselByIdV1 = Joi.object({
+  binary: Joi.boolean().default(false),
+  datasets: Joi.string().required(),
+});
+
+const schemaSearchVesselsV1 = Joi.object({
+  limit: Joi.number()
+    .integer()
+    .min(1)
+    .max(25)
+    .default(vesselDefault.limit),
+  query: Joi.string().required(),
+  binary: Joi.boolean().default(vesselDefault.binary),
+  suggestField: Joi.string().default(vesselDefault.suggestField),
+  queryFields: Joi.string().default(vesselDefault.queryFields),
+  querySuggestions: Joi.boolean().default(vesselDefault.querySuggestions),
+  offset: Joi.number()
+    .integer()
+    .min(0)
+    .default(vesselDefault.offset),
+  datasets: Joi.string().required(),
+});
+
+module.exports= {
+  schemaGetAllVesselsV1,
+  schemaGetVesselByIdV1,
+  schemaSearchVesselsV1
+}

--- a/src/validation/schemas/vessel.schemas.js
+++ b/src/validation/schemas/vessel.schemas.js
@@ -1,5 +1,5 @@
 const Joi = require('@hapi/joi');
-const { VESSELS_CONSTANTS: { DEFAULT_PROPERTY_SUGGEST } } = require('../constant');
+const { VESSELS_CONSTANTS: { DEFAULT_PROPERTY_SUGGEST } } = require('../../constant');
 
 const vesselDefault = {
   offset: 0,

--- a/src/validation/vessel.validation.js
+++ b/src/validation/vessel.validation.js
@@ -57,13 +57,13 @@ async function getAllVesselsV1Validation(ctx, next) {
   await next();
 }
 
-const schemaVesselDatasetV1 = Joi.object({
+const schemaGetVesselByIdV1 = Joi.object({
   binary: Joi.boolean().default(false),
   datasets: Joi.string().required(),
 });
-async function vesselIdV1Validation(ctx, next) {
+async function getVesselByIdV1Validation(ctx, next) {
   try {
-    const value = await schemaVesselDatasetV1.validateAsync(ctx.request.query);
+    const value = await schemaGetVesselByIdV1.validateAsync(ctx.request.query);
     Object.keys(value).forEach(k => {
       ctx.query[k] = value[k];
     });
@@ -155,7 +155,7 @@ async function advanceSearchSqlValidation(ctx, next) {
 
 module.exports = {
   getAllVesselsV1Validation,
-  vesselIdV1Validation,
+  getVesselByIdV1Validation,
   vesselSearchV1Validation,
   advanceSearchSqlValidation,
 };

--- a/src/validation/vessel.validation.js
+++ b/src/validation/vessel.validation.js
@@ -24,42 +24,26 @@ const vesselDefault = {
   binary: false,
 };
 
-const mainSchemaVesselV1 = {
+const schemaGetAllVesselsV1 = Joi.object({
   limit: Joi.number()
     .integer()
     .min(1)
     .max(25)
     .default(vesselDefault.limit),
-  binary: Joi.boolean().default(vesselDefault.binary),
-  suggestField: Joi.string().default(vesselDefault.suggestField),
-  queryFields: Joi.string().default(vesselDefault.queryFields),
-  querySuggestions: Joi.boolean().default(vesselDefault.querySuggestions),
+    binary: Joi.boolean().default(vesselDefault.binary),
+  ids: Joi.string().required(),
   offset: Joi.number()
-    .integer()
-    .min(0)
-    .default(vesselDefault.offset),
+  .integer()
+  .min(0)
+  .default(vesselDefault.offset),
   datasets: Joi.string().required(),
-};
-const schemaVesselV1 = Joi.alternatives().try(
-  Joi.object().keys({
-    ...mainSchemaVesselV1,
-    query: Joi.string().required(),
-  }),
-  Joi.object().keys({
-    ...mainSchemaVesselV1,
-    ids: Joi.string().required(),
-  }),
-);
-async function vesselV1Validation(ctx, next) {
+});
+async function getAllVesselsV1Validation(ctx, next) {
   try {
-    const value = await schemaVesselV1.validateAsync(ctx.request.query);
-
+    const value = await schemaGetAllVesselsV1.validateAsync(ctx.request.query);
     Object.keys(value).forEach(k => {
       ctx.query[k] = value[k];
     });
-    if (ctx.query.queryFields && !Array.isArray(ctx.query.queryFields)) {
-      ctx.query.queryFields = ctx.query.queryFields.split(',');
-    }
     if (ctx.query.ids && !Array.isArray(ctx.query.ids)) {
       ctx.query.ids = ctx.query.ids.split(',');
     }
@@ -170,7 +154,7 @@ async function advanceSearchSqlValidation(ctx, next) {
 }
 
 module.exports = {
-  vesselV1Validation,
+  getAllVesselsV1Validation,
   vesselIdV1Validation,
   vesselSearchV1Validation,
   advanceSearchSqlValidation,

--- a/src/validation/vessel.validation.js
+++ b/src/validation/vessel.validation.js
@@ -3,7 +3,7 @@ const {
 } = require('auth-middleware');
 const SqlWhereParser = require('sql-where-parser');
 const { VESSELS_CONSTANTS: { IMO, MMSI, SHIPNAME, VESSEL_ID, FLAG, CALLSIGN } } = require('../constant');
-const { sanitizeSQL } = require('../utils/sanitize-sql');
+const { removeWhitespace } = require('../utils/remove-whitespace');
 const { splitDatasets } = require('../utils/split-datasets');
 const {
   schemaGetAllVesselsV1,
@@ -105,7 +105,7 @@ async function advanceSearchSqlValidation(ctx, next) {
   try {
     const { query: { query: sql } } = ctx;
     const parser = new SqlWhereParser();
-    const whereParsed = parser.parse(sanitizeSQL(sql));
+    const whereParsed = parser.parse(removeWhitespace(sql));
     validateFields(whereParsed, [IMO, MMSI, SHIPNAME, VESSEL_ID, FLAG, CALLSIGN]);
     ctx.query.query.sql = sql;
   } catch (err) {


### PR DESCRIPTION
* Refactor endpoints. Now the API exposes:
`
/vessels <- list vessels, the ids query param is required to get a list of vessels by id.
/vessels/:id <- get vessel by id
/vessels/search <- basic search (previous search)
/vessels/advanced-search <- the new search
`

* Refactor de vessels validations to reuse code and keep the code clean
* Update swagger